### PR TITLE
rearange caption

### DIFF
--- a/_includes/flanders.html
+++ b/_includes/flanders.html
@@ -8,6 +8,13 @@
         ></a>
    </div>
    <figcaption style="display: block">
+       <a href="/MAE-gf/images_flanders/{{ include.src }}.JPG"
+          target="_blank"
+       >zoom in</a>
+       -
+       <a href="https://d-bl.github.io/GroundForge/tiles?repeatWidth=11&repeatHeight=11&c1={{ include.d1 }}&d1={{ include.a1 }}&e1={{ include.b1 }}&c2={{ include.d2 }}&e2={{ include.b2 }}&d3={{ include.c1 }}&shiftColsSE=2&shiftRowsSE=2&shiftColsSW=-2&shiftRowsSW=2&footside=-5,B-,-2,b-,,&tile=831,4-7,-5-&headside=5-,-c,6-,-c"
+          target="_blank"
+       >diagrams</a>
        <table style="width:150px">
            <tr><td>{{ include.d1 }}</td><td>{{ include.a1 }}</td><td>{{ include.b1 }}</td></tr>
            <tr><td>{{ include.d2 }}</td><td>&bull;</td><td>{{ include.b2 }}</td></tr>
@@ -17,13 +24,5 @@
            {{ include.name }},
        {% endif %}
        {{ include.src }}
-       <br>
-       <a href="/MAE-gf/images_flanders/{{ include.src }}.JPG"
-          target="_blank"
-       >zoom in</a>
-       -
-       <a href="https://d-bl.github.io/GroundForge/tiles?repeatWidth=11&repeatHeight=11&c1={{ include.d1 }}&d1={{ include.a1 }}&e1={{ include.b1 }}&c2={{ include.d2 }}&e2={{ include.b2 }}&d3={{ include.c1 }}&shiftColsSE=2&shiftRowsSE=2&shiftColsSW=-2&shiftRowsSW=2&footside=-5,B-,-2,b-,,&tile=831,4-7,-5-&headside=5-,-c,6-,-c"
-          target="_blank"
-       >diagrams</a>
    </figcaption>
 </figure>

--- a/_includes/flanders.html
+++ b/_includes/flanders.html
@@ -15,14 +15,15 @@
        <a href="https://d-bl.github.io/GroundForge/tiles?repeatWidth=11&repeatHeight=11&c1={{ include.d1 }}&d1={{ include.a1 }}&e1={{ include.b1 }}&c2={{ include.d2 }}&e2={{ include.b2 }}&d3={{ include.c1 }}&shiftColsSE=2&shiftRowsSE=2&shiftColsSW=-2&shiftRowsSW=2&footside=-5,B-,-2,b-,,&tile=831,4-7,-5-&headside=5-,-c,6-,-c"
           target="_blank"
        >diagrams</a>
+       <br>
+       {% if include.name %}
+           {{ include.name }},
+       {% endif %}
+       {{ include.src }}
        <table style="width:150px">
            <tr><td>{{ include.d1 }}</td><td>{{ include.a1 }}</td><td>{{ include.b1 }}</td></tr>
            <tr><td>{{ include.d2 }}</td><td>&bull;</td><td>{{ include.b2 }}</td></tr>
            <tr><td>{{ include.b1 }}</td><td>{{ include.c1 }}</td><td>{{ include.d1 }}</td></tr>
        </table>
-       {% if include.name %}
-           {{ include.name }},
-       {% endif %}
-       {{ include.src }}
    </figcaption>
 </figure>


### PR DESCRIPTION
I'd like to refer to the flanders page with a phrase like '... the diagram links in the image captions ...'. The tables between the images and the text would it confusing.

You can preview the result on https://jo-pol.github.io/MAE-gf/docs/flanders#grounds